### PR TITLE
Closes #35 chore: remove ramda and add sanctuary to dependencies

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@storybook/react'
 
 import hljs from 'highlight.js/lib/highlight'
-import { map } from 'ramda'
+import { map } from 'sanctuary'
 
 import 'highlight.js/styles/paraiso-light.css'
 
@@ -12,7 +12,7 @@ hljs.registerLanguage(
 const req = require.context('../src/', true, /\.stories\.js$/)
 
 function loadStories () {
-  map(filename => req(filename), req.keys())
+  map(filename => req(filename))(req.keys())
 }
 
 configure(loadStories, module)

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "browserslist": "> 0.25%, ie 10, ie 11, not op_mini all",
   "dependencies": {
     "dayjs": "^1.8.8",
-    "ramda": "^0.26.1",
-    "ramda-adjunct": "^2.16.1",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
+    "sanctuary": "^1.0.0",
+    "sanctuary-def": "^0.19.0",
     "styled-components": "^4.1.3",
     "styled-map": "^3.2.0-rc.1"
   },
@@ -85,7 +85,6 @@
     "react-testing-library": "^6.0.0",
     "regenerator-runtime": "^0.13.1",
     "rimraf": "^2.6.3",
-    "sanctuary": "^1.0.0",
     "semantic-release": "^15.13.3",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack-cli": "^3.2.3"

--- a/src/components/SingleLineStringField/index.js
+++ b/src/components/SingleLineStringField/index.js
@@ -1,11 +1,11 @@
 import * as React from 'react'
-
-import { isEmpty, not } from 'ramda'
+import { not } from 'sanctuary'
 
 import useFieldState from '../../hooks/useFieldState'
 import Button from '../styled/Button'
 import Input from '../styled/Input'
 import Label from '../styled/Label'
+import isEmpty from '../../utils/isEmpty'
 
 export default function Field (props) {
   const {

--- a/src/components/SingleLineStringField/index.stories.js
+++ b/src/components/SingleLineStringField/index.stories.js
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import SingleLineStringField from '.'
+
+storiesOf('SingleLineStringField', module).add('base', () => (
+  <SingleLineStringField />
+))

--- a/src/hooks/useFieldState/getUndoRedo/index.js
+++ b/src/hooks/useFieldState/getUndoRedo/index.js
@@ -1,6 +1,5 @@
 import { REDO, UNDO } from '../constants'
-
-import { isEmpty } from 'ramda'
+import isEmpty from '../../../utils/isEmpty'
 
 export default function getUndoRedo (state, dispatch, disabled) {
   if (disabled) {

--- a/src/hooks/useFieldState/reducer/index.js
+++ b/src/hooks/useFieldState/reducer/index.js
@@ -1,5 +1,6 @@
-import { head, isNil, prepend, tail } from 'ramda'
+import { head, prepend, tail, maybeToNullable } from 'sanctuary'
 
+import isNil from '../../../utils/isNil'
 import { CLEAR, REDO, RESET, UNDO, UPDATE } from '../constants'
 
 function handleClear ({ undo, value }) {
@@ -9,7 +10,7 @@ function handleClear ({ undo, value }) {
 
   return {
     value: '',
-    undo: prepend(value, undo)
+    undo: prepend(value)(undo)
   }
 }
 
@@ -19,9 +20,9 @@ function handleRedo ({ redo, undo, value }) {
   }
 
   return {
-    undo: prepend(value, undo),
-    redo: tail(redo),
-    value: head(redo)
+    undo: prepend(value)(undo),
+    redo: maybeToNullable(tail(redo)),
+    value: maybeToNullable(head(redo))
   }
 }
 
@@ -43,7 +44,7 @@ function handleUpdate ({ undo, value }, newValue) {
   }
 
   return {
-    undo: prepend(value, undo),
+    undo: prepend(value)(undo),
     value: newValue
   }
 }
@@ -54,9 +55,9 @@ function handleUndo ({ redo, undo, value }) {
   }
 
   return {
-    undo: tail(undo),
-    redo: prepend(value, redo),
-    value: head(undo)
+    undo: maybeToNullable(tail(undo)),
+    redo: prepend(value)(redo),
+    value: maybeToNullable(head(undo))
   }
 }
 

--- a/src/utils/isEmpty/index.js
+++ b/src/utils/isEmpty/index.js
@@ -1,0 +1,15 @@
+import { is, size } from 'sanctuary'
+import $ from 'sanctuary-def'
+
+export default function isEmpty (value) {
+  if (is($.String)(value)) {
+    return value === ''
+  }
+  if (is($.Object)(value)) {
+    return size(value) === 0
+  }
+  if (is($.Array0)(value)) {
+    return true
+  }
+  return false
+}

--- a/src/utils/isEmpty/index.spec.js
+++ b/src/utils/isEmpty/index.spec.js
@@ -1,0 +1,19 @@
+import isEmpty from '.'
+
+describe('utils:isEmpty', () => {
+  it('returns true when value is an empty string', () => {
+    expect(isEmpty('')).toEqual(true)
+  })
+  it('returns true when value is an empty array', () => {
+    expect(isEmpty([])).toEqual(true)
+  })
+  it('returns true when value is an empty object', () => {
+    expect(isEmpty({})).toEqual(true)
+  })
+  it('returns false for all other values', () => {
+    expect(isEmpty('test')).toEqual(false)
+    expect(isEmpty(5)).toEqual(false)
+    expect(isEmpty(['hello'])).toEqual(false)
+    expect(isEmpty({ hi: 'there' })).toEqual(false)
+  })
+})

--- a/src/utils/isNil/index.js
+++ b/src/utils/isNil/index.js
@@ -1,0 +1,3 @@
+export default function isNil (value) {
+  return value === null || value === undefined
+}

--- a/src/utils/isNil/index.spec.js
+++ b/src/utils/isNil/index.spec.js
@@ -1,0 +1,16 @@
+import isNil from '.'
+
+describe('utils:isNil', () => {
+  it('returns true when value is null', () => {
+    expect(isNil(null)).toEqual(true)
+  })
+  it('returns true when value is undefined', () => {
+    expect(isNil(undefined)).toEqual(true)
+  })
+  it('returns false for all other values', () => {
+    expect(isNil('test')).toEqual(false)
+    expect(isNil(5)).toEqual(false)
+    expect(isNil(['hello'])).toEqual(false)
+    expect(isNil({ hi: 'there' })).toEqual(false)
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,9 +37,6 @@ const toolkit = {
     libraryTarget: 'umd',
     library: 'centripetal-toolkit',
   },
-  externals: {
-    ramda: 'ramda',
-  },
   module: {
     rules: [
       {
@@ -80,9 +77,6 @@ const toolkitMin = Object.assign(
       filename: 'centripetal-toolkit.node.min.js',
       libraryTarget: 'umd',
       library: 'centripetal-toolkit',
-    },
-    externals: {
-      ramda: 'ramda',
     },
     module: {
       rules: [
@@ -125,9 +119,6 @@ const toolkitWeb = {
     filename: 'centripetal-toolkit.web.js',
     libraryTarget: 'umd',
     library: 'centripetal-toolkit',
-  },
-  externals: {
-    ramda: 'R',
   },
   module: {
     rules: [
@@ -174,9 +165,6 @@ const toolkitWebMin = Object.assign(
       filename: 'centripetal-toolkit.web.min.js',
       libraryTarget: 'umd',
       library: 'centripetal-toolkit',
-    },
-    externals: {
-      ramda: 'R',
     },
     module: {
       rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -10576,20 +10576,10 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-ramda-adjunct@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/ramda-adjunct/-/ramda-adjunct-2.16.1.tgz#19af36ed58bc1b7bc90c16c4d814bbd5f16ce64c"
-  integrity sha512-0fvgqMLpRbXrDq2V/FhR1m0gEDCO2ANANXBBbhQrZYYHDLfJUDuLAiuE2fnbjM5HkCaFbL7MfATkafkyxp2AAw==
-
 ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
-
-ramda@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
@@ -11470,7 +11460,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sanctuary-def@0.19.0:
+sanctuary-def@0.19.0, sanctuary-def@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.19.0.tgz#84dd038f723512168028654dd89563cbbf3a34af"
   integrity sha512-1ZJX4LC3Kh4B9bnGGCN8qQS7GrHltLtibQnsaFqaoUpKIT4qCfUuCy/Beke352E948+lmquowyDfkMHtZ/0m3w==


### PR DESCRIPTION
Removed Ramda and Ramda-Adjunct and added Sanctuary and Sanctuary-Def to dependencies. Also changed the files to not use Ramda. Added two utility functions `isEmpty` and `isNil` and added corresponding tests.